### PR TITLE
Transfer ownership to mathbook-io | Merge to Develop

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,9 +32,9 @@ The Mathbook project is hosted on GitHub and there is an issues section where yo
 bug.
 
 Please make sure to follow the bug reporting guidelines outlined
-[here](https://github.com/JetJet13/mathbook/wiki/Bug-Reporting-Guideline).
+[here](https://github.com/mathbook-io/mathbook/wiki/Bug-Reporting-Guideline).
 
-[Click here to go the issues page for Mathbook](https://github.com/JetJet13/mathbook/issues)
+[Click here to go the issues page for Mathbook](https://github.com/mathbook-io/mathbook/issues)
 
 ## I want to fix/squash some bugs
 
@@ -44,7 +44,7 @@ smaller bugs.
 If and when you get comfortable fixing bugs and making changes to the source code, you are more than welcome to making
 the jump towards squashing bigger bugs.
 
-[Click here to view the current list of reported bugs](https://github.com/JetJet13/mathbook/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3Abug+)
+[Click here to view the current list of reported bugs](https://github.com/mathbook-io/mathbook/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3Abug+)
 
 ## I want to write some documentation
 
@@ -54,7 +54,7 @@ understanding how Mathbook works under the hood.
 Writing documentation requires knowledge of the inner workings of Mathbook and the reasoning behind the decisions made
 in the architecture and source code.
 
-The documentation for Mathbook lives [here](https://github.com/JetJet13/mathbook/wiki)
+The documentation for Mathbook lives [here](https://github.com/mathbook-io/mathbook/wiki)
 
 We recommend reading through some parts of the docs to get an idea of what's needed to contribute to the docs, ie)
 formatting, providing examples and maybe even referencing some part of the source code
@@ -72,7 +72,7 @@ For Mathbook, the testing framework we use is [Chai](http://chaijs.com/) and our
 
 Check out the tests folder in the [source code](./tests) to get an idea of how we structure our test suites.
 
-You can also check out the [documentation](https://github.com/JetJet13/mathbook/wiki/Testing-Documentation) to learn
+You can also check out the [documentation](https://github.com/mathbook-io/mathbook/wiki/Testing-Documentation) to learn
 about the reasoning behind the different types of tests that we write.
 
 ## I want to provide some feedback
@@ -83,7 +83,7 @@ improved, let us know.
 You can create an issue on GitHub and tag the issue with the proper tag that reflects your feedback (we have a bunch of
 tags, pick one that best represents your feedback).
 
-[Click here to go the issues page and provide some feedback](https://github.com/JetJet13/mathbook/issues)
+[Click here to go the issues page and provide some feedback](https://github.com/mathbook-io/mathbook/issues)
 
 ## Contributor Behavior
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Build Status](https://travis-ci.org/JetJet13/mathbook.svg?branch=develop)](https://travis-ci.org/JetJet13/mathbook)
-[![Greenkeeper badge](https://badges.greenkeeper.io/JetJet13/mathbook.svg)](https://greenkeeper.io/)
+[![Build Status](https://travis-ci.org/mathbook-io/mathbook.svg?branch=develop)](https://travis-ci.org/mathbook-io/mathbook)
+[![Greenkeeper badge](https://badges.greenkeeper.io/mathbook-io/mathbook.svg)](https://greenkeeper.io/)
 [![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/mathbook-chat/Lobby)
 
 ![mathbook-logo](./src/front-end/public/images/mathbook_indigo_white_v5.png)
@@ -16,14 +16,14 @@ in JavaScript and built using NodeJS, ExpressJS, Riot and Pug.
 ## Up and Running with Docker
 
 Please refer to the wiki to get
-[up and running with Docker](https://github.com/JetJet13/mathbook/wiki/Up-and-Running-with-Docker).
+[up and running with Docker](https://github.com/mathbook-io/mathbook/wiki/Up-and-Running-with-Docker).
 
 ## Local Installation & Setup
 
 #### Download/Clone Mathbook Repo & Install Dependencies
 
 ```bash
-git clone https://github.com/JetJet13/mathbook.git
+git clone https://github.com/mathbook-io/mathbook.git
 
 cd ./mathbook
 
@@ -35,11 +35,11 @@ npm i
 
 **[required]** - You will need a custom configuration file tailored to your local setup so go ahead and create a file in
 the `config` folder called `local.json`. You can grab a sample local config file
-[from the wiki here](<https://github.com/JetJet13/mathbook/wiki/Sample-Local-Configuration-File-(local.json)>).
+[from the wiki here](<https://github.com/mathbook-io/mathbook/wiki/Sample-Local-Configuration-File-(local.json)>).
 
 **[optional]** - This step if only needed if you want to get the authentication functionality of Mathbook to work. There
-is a [wiki page](<(https://github.com/JetJet13/mathbook/wiki/Setup-Your-GitHub-OAuth-Application)>) to get that up and
-running since its not required for a local setup.
+is a [wiki page](<(https://github.com/mathbook-io/mathbook/wiki/Setup-Your-GitHub-OAuth-Application)>) to get that up
+and running since its not required for a local setup.
 
 #### Downloading & Installing Redis
 

--- a/config/constants.json
+++ b/config/constants.json
@@ -1,5 +1,5 @@
 {
-  "OWNER": "JetJet13",
+  "OWNER": "mathbook-io",
   "REPO": "mathbook",
   "BRANCH_PREFIX": "tutorial",
   "TUTORIALS_PATH": "src/tutorials",

--- a/contributors.md
+++ b/contributors.md
@@ -1,5 +1,5 @@
 # Below is a list of the Contributors of Mathbook
 
-* mathbook-io
+* JetJet13
 * Gh0stByte
 * rich1126

--- a/contributors.md
+++ b/contributors.md
@@ -1,5 +1,5 @@
 # Below is a list of the Contributors of Mathbook
 
-* JetJet13
+* mathbook-io
 * Gh0stByte
 * rich1126

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mathbook",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mathbook",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mathbook",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "private": true,
   "scripts": {
     "start": "node ./bin/www",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mathbook",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "scripts": {
     "start": "node ./bin/www",

--- a/src/front-end/views/500.pug
+++ b/src/front-end/views/500.pug
@@ -7,6 +7,6 @@ block content
         p Uh-oh, there was an Internal Server Error. That means that your request was mishandled or something broke server side.
           br
           | Sorry about that. Feel free to raise an issue about this 
-          a(href="https://github.com/JetJet13/mathbook/issues" target="_blank") here
+          a(href="https://github.com/mathbook-io/mathbook/issues" target="_blank") here
         p
           a(href="/") Click Here to go back to the homepage.

--- a/src/front-end/views/contribute-components/create-tutorial.pug
+++ b/src/front-end/views/contribute-components/create-tutorial.pug
@@ -55,7 +55,7 @@ block info
               strong Note
               | : If you don't know much about TeX or HTML and CSS, don't worry about it too much, you can easily learn as you start building out the tutorial.
             p If you want to write a tutorial for a subject that is not listed in Mathbook, feel free to create an issue about it 
-              a(href="https://github.com/JetJet13/mathbook/issues" target="_blank") here
+              a(href="https://github.com/mathbook-io/mathbook/issues" target="_blank") here
               |  and a contributor will try their best to get it added in a timely manner.
             p When your tutorial gets approved and added to Mathbook, you will be added as a contributor (if you aren't one already).
             p The next section will talk about the different components that make up a tutorial.
@@ -144,7 +144,7 @@ block info
             p Once your tutorial gets approved and merged, it gets added to the collection of tutorials on Mathbook and 
               | your github account and name will be added to the contributors list.
             p You can take a look at the tutorials currently submitted for review
-              a(href='https://github.com/JetJet13/mathbook/pulls' target="_blank")  here
+              a(href='https://github.com/mathbook-io/mathbook/pulls' target="_blank")  here
             h3#start Start building your tutorial
             p For your convenience, here is a list of resources that we think will come in handy when you are creating your tutorial.
               ul

--- a/src/front-end/views/contribute-components/overview.pug
+++ b/src/front-end/views/contribute-components/overview.pug
@@ -45,11 +45,11 @@ block info
           br
           br
           | Please make sure to follow the bug reporting guidelines outlined 
-          a.is-link(href="https://github.com/JetJet13/mathbook/wiki/Bug-Reporting-Guideline" target="_blank") here
+          a.is-link(href="https://github.com/mathbook-io/mathbook/wiki/Bug-Reporting-Guideline" target="_blank") here
           |.
           br
           br
-          a(href="https://github.com/JetJet13/mathbook/issues" target="_blank") Click here to go the issues page for Mathbook
+          a(href="https://github.com/mathbook-io/mathbook/issues" target="_blank") Click here to go the issues page for Mathbook
           span(class="help has-text-grey") Note: You will need to create a GitHub account if you don't already have one to create an issue.
         
         h3#fix-bugs I want to fix/squash some bugs
@@ -59,7 +59,7 @@ block info
           | towards squashing bigger bugs.
           br
           br
-          a(href="https://github.com/JetJet13/mathbook/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3Abug+" target="_blank")
+          a(href="https://github.com/mathbook-io/mathbook/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3Abug+" target="_blank")
             | Click here to view the current list of reported bugs
 
 
@@ -69,7 +69,7 @@ block info
           | Writing documentation requires knowledge of the inner workings of Mathbook and the reasoning behind the decisions made in the architecture and source code.
         p.preWrap
           | The documentation for Mathbook lives 
-          a(href="https://github.com/JetJet13/mathbook/wiki" target="_blank") here
+          a(href="https://github.com/mathbook-io/mathbook/wiki" target="_blank") here
         p.preWrap
           | We recommend reading through some parts of the docs to get an idea of what's needed to contribute to the docs, ie) formatting, providing examples and 
           | maybe even referencing some part of the source code
@@ -90,10 +90,10 @@ block info
           a(href="http://sinonjs.org/" target="_blank") Sinon
           |  for stubbing/mocking and setting up spies. 
           | Check out the tests folder in the 
-          a(href="https://github.com/JetJet13/mathbook/tree/develop/tests" target="_blank") source code 
+          a(href="https://github.com/mathbook-io/mathbook/tree/develop/tests" target="_blank") source code 
           | to get an idea of how we structure our test suites. 
         p.preWrap You can also check out the 
-          a(href="https://github.com/JetJet13/mathbook/wiki/Testing-Documentation" target="_blank") documentation
+          a(href="https://github.com/mathbook-io/mathbook/wiki/Testing-Documentation" target="_blank") documentation
           |  to learn about the reasoning behind the different types of tests that we write.
 
         h3#feedback I want to provide some feedback
@@ -101,7 +101,7 @@ block info
           | Your feedback is always welcome. Do you have an idea for a new feature or think that some functionality could be improved, let us know.
           | You can create an issue on GitHub and tag the issue with the proper tag that reflects your feedback (we have a bunch of tags, pick one that best represents your feedback). 
         p
-          a(href="https://github.com/JetJet13/mathbook/issues" target="_blank") Click here to go the issues page and provide some feedback
+          a(href="https://github.com/mathbook-io/mathbook/issues" target="_blank") Click here to go the issues page and provide some feedback
           span(class="help has-text-grey") Note: You will need to create a GitHub account if you don't already have one to create an issue.
 
         h3#behavior Contributor Behavior

--- a/src/front-end/views/contribute-components/review-tutorial.pug
+++ b/src/front-end/views/contribute-components/review-tutorial.pug
@@ -16,7 +16,7 @@ block info
           | and the tutorial remains in a state of approval, it will be merged and added to Mathbook. That tutorial will then be added to the next release of Mathbook,
           | which depending on the number of tutorials and features and bug fixes, can vary (from the same day to a week).
         p All pull requests for tutorials that have been submitted for review live 
-          a(href="https://github.com/JetJet13/mathbook/pulls") here
+          a(href="https://github.com/mathbook-io/mathbook/pulls") here
           |.
         h3 What do I need to do ?
         p You'll notice that every tutorial has a description box with a link to preview the tutorial. This link will navigate you to Mathbook 

--- a/src/front-end/views/layout.pug
+++ b/src/front-end/views/layout.pug
@@ -72,14 +72,14 @@ html
       .container
         .content.has-text-centered
           p.my-footer-text
-            a.my-footer-text(target='_blank', href='https://github.com/jetjet13/mathbook')
+            a.my-footer-text(target='_blank', href='https://github.com/mathbookio/mathbook')
               strong Mathbook
-            |  was created by Johny Georges
-            a.icon.my-footer-text(target='_blank', href='https://github.com/jetjet13')
+            |  would not be possible without its talented Contributors.
+            a.icon.my-footer-text(target='_blank', href='https://github.com/mathbookio/mathbook/contributors.md')
               i.fa.fa-github
           p.my-footer-text
             | Licensed under 
-            a.my-footer-text(target='_blank', href='https://github.com/JetJet13/mathbook/blob/develop/LICENSE') 
+            a.my-footer-text(target='_blank', href='https://github.com/mathbookio/mathbook/blob/develop/LICENSE') 
               strong Mozilla Public License 2.0 
             a(target="_blank" href="https://opensource.org/")
               span.icon.is-small

--- a/src/front-end/views/layout.pug
+++ b/src/front-end/views/layout.pug
@@ -72,14 +72,14 @@ html
       .container
         .content.has-text-centered
           p.my-footer-text
-            a.my-footer-text(target='_blank', href='https://github.com/mathbookio/mathbook')
+            a.my-footer-text(target='_blank', href='https://github.com/mathbook-io/mathbook')
               strong Mathbook
             |  would not be possible without its talented Contributors.
-            a.icon.my-footer-text(target='_blank', href='https://github.com/mathbookio/mathbook/contributors.md')
+            a.icon.my-footer-text(target='_blank', href='https://github.com/mathbook-io/mathbook/contributors.md')
               i.fa.fa-github
           p.my-footer-text
             | Licensed under 
-            a.my-footer-text(target='_blank', href='https://github.com/mathbookio/mathbook/blob/develop/LICENSE') 
+            a.my-footer-text(target='_blank', href='https://github.com/mathbook-io/mathbook/blob/develop/LICENSE') 
               strong Mozilla Public License 2.0 
             a(target="_blank" href="https://opensource.org/")
               span.icon.is-small


### PR DESCRIPTION
# Changes & Additions

* replaced `JetJet13` with `mathbook-io` everywhere in the app.

---

**Issue:** #87 

---

# Reason
In order to transfer the ownership of Mathbook from JetJet13 to mathbook-io, we need to make sure all urls point to the new future location of the repo.
